### PR TITLE
Fix LTI2 Registration with Canvas

### DIFF
--- a/src/ToolProvider/MediaType/ToolProfile.php
+++ b/src/ToolProvider/MediaType/ToolProfile.php
@@ -58,7 +58,7 @@ class ToolProfile
             }            
         }
         if (!empty($toolProvider->vendor->id)) {
-            $this->product_instance->product_info->product_family->vendor->code = $toolProvider->vendor->id;            
+            $this->product_instance->product_info->product_family->vendor->code = $toolProvider->vendor->id;
         }
         if (!empty($toolProvider->vendor->name)) {
             $this->product_instance->product_info->product_family->vendor->vendor_name = new \stdClass;

--- a/src/ToolProvider/MediaType/ToolProfile.php
+++ b/src/ToolProvider/MediaType/ToolProfile.php
@@ -53,10 +53,12 @@ class ToolProfile
         if (!empty($toolProvider->vendor)) {
             $this->product_instance->product_info->product_family = new \stdClass;
             $this->product_instance->product_info->product_family->vendor = new \stdClass;
+            if (!empty($toolProvider->product->id)) {
+                $this->product_instance->product_info->product_family->code = $toolProvider->product->id;
+            }            
         }
         if (!empty($toolProvider->vendor->id)) {
-            $this->product_instance->product_info->product_family->vendor->code = $toolProvider->vendor->id;
-            $this->product_instance->product_info->product_family->code = $toolProvider->vendor->id;
+            $this->product_instance->product_info->product_family->vendor->code = $toolProvider->vendor->id;            
         }
         if (!empty($toolProvider->vendor->name)) {
             $this->product_instance->product_info->product_family->vendor->vendor_name = new \stdClass;

--- a/src/ToolProvider/MediaType/ToolProfile.php
+++ b/src/ToolProvider/MediaType/ToolProfile.php
@@ -56,6 +56,7 @@ class ToolProfile
         }
         if (!empty($toolProvider->vendor->id)) {
             $this->product_instance->product_info->product_family->vendor->code = $toolProvider->vendor->id;
+            $this->product_instance->product_info->product_family->code = $toolProvider->vendor->id;
         }
         if (!empty($toolProvider->vendor->name)) {
             $this->product_instance->product_info->product_family->vendor->vendor_name = new \stdClass;


### PR DESCRIPTION
When trying to do LTI2 Registration with Canvas I get back:

> {"errors":[{"field":"product_code","message":null,"error_code":"blank"}],"error_report_id":155315614}

The reason is this code:

```ruby
def create_product_family(tp, account, developer_key)
  vendor_code = tp.tool_profile.product_instance.product_info.product_family.vendor.code
  product_code = tp.tool_profile.product_instance.product_info.product_family.code
```

Source: https://github.com/instructure/canvas-lms/blob/0063478e81b0175f47ce0698345b3b8f42e6d52a/app/models/lti/tool_proxy_service.rb#L125

When I change ToolProvider/MediaType/ToolProfile.php from:

```php
if (!empty($toolProvider->vendor->id)) { 
  $this->product_instance->product_info->product_family->vendor->code = $toolProvider->vendor->id;	
}
```

To:

```php
if (!empty($toolProvider->vendor->id)) { 
  $this->product_instance->product_info->product_family->vendor->code = $toolProvider->vendor->id; 
  $this->product_instance->product_info->product_family->code = $toolProvider->vendor->id; }
```

Ir works.

Unsure if it should be the same vendor ID though. Here's the spec: https://www.imsglobal.org/specs/ltiv2p0/implementation-guide#toc-68