### PR TITLE
Fix parseRoles for Canvas style roles

### DIFF
--- a/src/ToolProvider/ToolProvider.php
+++ b/src/ToolProvider/ToolProvider.php
@@ -457,6 +457,13 @@ class ToolProvider
         foreach ($roles as $role) {
             $role = trim($role);
             if (!empty($role)) {
+                if (strpos( $role, '://purl.imsglobal.org/vocab/lis/v2/' ) !== false) {
+                    // Get trailing #anchor
+                    $fragment = parse_url($role, PHP_URL_FRAGMENT);
+                    if (!empty( $fragment )) {
+                        $role = $fragment;
+                    }
+                }                
                 if (substr($role, 0, 4) !== 'urn:') {
                     $role = 'urn:lti:role:ims/lis/' . $role;
                 }


### PR DESCRIPTION
Roles in Canvas look like this:

```ruby
    LIS_V2_ROLE_MAP = {
      'user' => 'http://purl.imsglobal.org/vocab/lis/v2/system/person#User',
      'siteadmin' => 'http://purl.imsglobal.org/vocab/lis/v2/system/person#SysAdmin',

      'teacher' => 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Instructor',
      'student' => 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Student',
      'admin' => 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator',
      AccountUser => 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator',
      TaEnrollment => ['http://purl.imsglobal.org/vocab/lis/v2/membership/instructor#TeachingAssistant', 'http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor'],
      StudentEnrollment => 'http://purl.imsglobal.org/vocab/lis/v2/membership#Learner',
      TeacherEnrollment => 'http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor',
      DesignerEnrollment => 'http://purl.imsglobal.org/vocab/lis/v2/membership#ContentDeveloper',
      ObserverEnrollment => 'http://purl.imsglobal.org/vocab/lis/v2/membership#Mentor',
      StudentViewEnrollment => 'http://purl.imsglobal.org/vocab/lis/v2/membership#Learner'
    }
```

So if you pop out the #anchor they work with `isLearner` `isStaff` and `isAdmin`

 + Source: https://github.com/instructure/canvas-lms/blob/e5a181caa320bcec6ca8394dc2a0d35b02e207a2/lib/lti/substitutions_helper.rb#L42
+ Related: https://github.com/IMSGlobal/LTI-Tool-Provider-Library-PHP/issues/23