### PR TITLE
Add missing Outcome result data

### DIFF
--- a/src/ToolProvider/Outcome.php
+++ b/src/ToolProvider/Outcome.php
@@ -13,6 +13,15 @@ namespace IMSGlobal\LTI\ToolProvider;
  */
 class Outcome
 {
+/**
+ * Text Data Type
+ */
+    const DATA_TYPE_TEXT = 'text';
+
+/**
+ * Url Data Type
+ */
+    const DATA_TYPE_URL = 'url';
 
 /**
  * Language value.
@@ -53,17 +62,33 @@ class Outcome
     private $value = null;
 
 /**
+ * Data value.
+ *
+ * @var string $data
+ */
+    private $data = null;
+
+/**
+ * Data Type value.
+ *
+ * @var string $dataType
+ */
+    private $dataType = null;
+
+/**
  * Class constructor.
  *
  * @param string $value     Outcome value (optional, default is none)
  */
-    public function __construct($value = null)
+    public function __construct($value = null, $data = null)
     {
 
         $this->value = $value;
         $this->language = 'en-US';
         $this->date = gmdate('Y-m-d\TH:i:s\Z', time());
         $this->type = 'decimal';
+        $this->data = $data;
+        $this->dataType = self::DATA_TYPE_TEXT;
 
     }
 
@@ -88,6 +113,53 @@ class Outcome
     {
 
         $this->value = $value;
+
+    }
+
+/**
+ * Get the data value.
+ *
+ * @return string Data value
+ */
+    public function getData()
+    {
+
+        return $this->data;
+
+    }
+
+/**
+ * Set the data value.
+ *
+ * @param string $data  Data value
+ */
+    public function setData($data)
+    {
+
+        $this->data = $data;
+
+    }
+/**
+ * Get the dataType value.
+ *
+ * @return string DataType value
+ */
+    public function getDataType()
+    {
+
+        return $this->dataType;
+
+    }
+
+/**
+ * Set the dataType value.
+ *
+ * @param string $dataType  DataType value
+ */
+    public function setDataType($dataType)
+    {
+
+        $this->dataType = $dataType;
 
     }
 

--- a/src/ToolProvider/ResourceLink.php
+++ b/src/ToolProvider/ResourceLink.php
@@ -591,13 +591,22 @@ class ResourceLink
             if ($urlLTI11) {
                 $xml = '';
                 if ($action === self::EXT_WRITE) {
+                    if(!empty($ltiOutcome->getData())) {
+                        $xml = <<<EOF
+
+          <resultData>
+            <{$ltiOutcome->getDataType()}>{$ltiOutcome->getData()}</{$ltiOutcome->getDataType()}>
+          </resultData>
+EOF;
+                    }
+
                     $xml = <<<EOF
 
         <result>
           <resultScore>
             <language>{$ltiOutcome->language}</language>
             <textString>{$value}</textString>
-          </resultScore>
+          </resultScore>{$xml}
         </result>
 EOF;
                 }


### PR DESCRIPTION
There is currently no way to attach a result data to an outcome.
This adds that feature. :)